### PR TITLE
Feature/options per host

### DIFF
--- a/lib/capistrano/tasks/monit.cap
+++ b/lib/capistrano/tasks/monit.cap
@@ -25,22 +25,25 @@ namespace :sidekiq do
 
     desc 'Config Sidekiq monit-service'
     task :config do
-      on roles(fetch(:sidekiq_role)) do |role|
-        @role = role
-        upload_sidekiq_template 'sidekiq_monit', "#{fetch(:tmp_dir)}/monit.conf", @role
+      Array(fetch(:sidekiq_role)).each do |role_name|
+        on roles(role_name) do |role|
+          @role = role
+          @role_name = role_name
+          upload_sidekiq_template 'sidekiq_monit', "#{fetch(:tmp_dir)}/monit.conf", @role
 
-        mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{sidekiq_service_name}.conf"
-        sudo_if_needed mv_command
+          mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{sidekiq_service_name}.conf"
+          sudo_if_needed mv_command
 
-        sudo_if_needed "#{fetch(:monit_bin)} reload"
+          sudo_if_needed "#{fetch(:monit_bin)} reload"
+        end
       end
     end
 
     desc 'Monitor Sidekiq monit-service'
     task :monitor do
-      Array(fetch(:sidekiq_role)).each do |role|
-        on roles(role) do
-          sidekiq_processes(role).times do |idx|
+      Array(fetch(:sidekiq_role)).each do |role_name|
+        on roles(role_name) do
+          sidekiq_processes(role_name).times do |idx|
             begin
               sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"
             rescue
@@ -54,9 +57,9 @@ namespace :sidekiq do
 
     desc 'Unmonitor Sidekiq monit-service'
     task :unmonitor do
-      Array(fetch(:sidekiq_role)).each do |role|
-        on roles(role) do
-          sidekiq_processes(role).times do |idx|
+      Array(fetch(:sidekiq_role)).each do |role_name|
+        on roles(role_name) do
+          sidekiq_processes(role_name).times do |idx|
             begin
               sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sidekiq_service_name(idx)}"
             rescue
@@ -69,9 +72,9 @@ namespace :sidekiq do
 
     desc 'Start Sidekiq monit-service'
     task :start do
-      Array(fetch(:sidekiq_role)).each do |role|
-        on roles(role) do
-          sidekiq_processes(role).times do |idx|
+      Array(fetch(:sidekiq_role)).each do |role_name|
+        on roles(role_name) do
+          sidekiq_processes(role_name).times do |idx|
             sudo_if_needed "#{fetch(:monit_bin)} start #{sidekiq_service_name(idx)}"
           end
         end
@@ -80,9 +83,9 @@ namespace :sidekiq do
 
     desc 'Stop Sidekiq monit-service'
     task :stop do
-      Array(fetch(:sidekiq_role)).each do |role|
-        on roles(role) do
-          sidekiq_processes(role).times do |idx|
+      Array(fetch(:sidekiq_role)).each do |role_name|
+        on roles(role_name) do
+          sidekiq_processes(role_name).times do |idx|
             sudo_if_needed "#{fetch(:monit_bin)} stop #{sidekiq_service_name(idx)}"
           end
         end
@@ -91,9 +94,9 @@ namespace :sidekiq do
 
     desc 'Restart Sidekiq monit-service'
     task :restart do
-      Array(fetch(:sidekiq_role)).each do |role|
-        on roles(role) do
-          sidekiq_processes(role).times do |idx|
+      Array(fetch(:sidekiq_role)).each do |role_name|
+        on roles(role_name) do
+          sidekiq_processes(role_name).times do |idx|
             sudo_if_needed"#{fetch(:monit_bin)} restart #{sidekiq_service_name(idx)}"
           end
         end

--- a/lib/capistrano/tasks/sidekiq.cap
+++ b/lib/capistrano/tasks/sidekiq.cap
@@ -53,6 +53,10 @@ namespace :sidekiq do
     pids
   end
 
+  def sidekiq_options_per_process(role = nil)
+    fetch(:"#{ role }_options_per_process") || fetch(:sidekiq_options_per_process)
+  end
+
   def pid_process_exists?(pid_file)
     pid_file_exists?(pid_file) and test(*("kill -0 $( cat #{pid_file} )").split(' '))
   end
@@ -86,7 +90,7 @@ namespace :sidekiq do
     end
   end
 
-  def start_sidekiq(pid_file, idx = 0)
+  def start_sidekiq(role, pid_file, idx = 0)
     args = []
     args.push "--index #{idx}"
     args.push "--pidfile #{pid_file}"
@@ -99,7 +103,7 @@ namespace :sidekiq do
     end
     args.push "--config #{fetch(:sidekiq_config)}" if fetch(:sidekiq_config)
     args.push "--concurrency #{fetch(:sidekiq_concurrency)}" if fetch(:sidekiq_concurrency)
-    if process_options = fetch(:sidekiq_options_per_process)
+    if process_options = sidekiq_options_per_process(role)
       args.push process_options[idx]
     end
     # use sidekiq_options for special options
@@ -154,9 +158,11 @@ namespace :sidekiq do
 
   desc 'Start sidekiq'
   task :start do
-    on roles fetch(:sidekiq_role) do
-      for_each_process do |pid_file, idx|
-        start_sidekiq(pid_file, idx) unless pid_process_exists?(pid_file)
+    Array(fetch(:sidekiq_role)).each do |role|
+      on roles(role) do
+        for_each_process do |pid_file, idx|
+          start_sidekiq(role, pid_file, idx) unless pid_process_exists?(pid_file)
+        end
       end
     end
   end
@@ -169,12 +175,14 @@ namespace :sidekiq do
 
   desc 'Rolling-restart sidekiq'
   task :rolling_restart do
-    on roles fetch(:sidekiq_role) do
-      for_each_process(true) do |pid_file, idx|
-        if pid_process_exists?(pid_file)
-          stop_sidekiq(pid_file)
+    Array(fetch(:sidekiq_role)).each do |role|
+      on roles(role) do
+        for_each_process(true) do |pid_file, idx|
+          if pid_process_exists?(pid_file)
+            stop_sidekiq(pid_file)
+          end
+          start_sidekiq(role, pid_file, idx)
         end
-        start_sidekiq(pid_file, idx)
       end
     end
   end
@@ -194,10 +202,13 @@ namespace :sidekiq do
   desc 'Respawn missing sidekiq processes'
   task :respawn do
     invoke 'sidekiq:cleanup'
-    on roles fetch(:sidekiq_role) do
-      for_each_process do |pid_file, idx|
-        unless pid_file_exists?(pid_file)
-          start_sidekiq(pid_file, idx)
+
+    Array(fetch(:sidekiq_role)).each do |role|
+      on roles(role) do
+        for_each_process do |pid_file, idx|
+          unless pid_file_exists?(pid_file)
+            start_sidekiq(role, pid_file, idx)
+          end
         end
       end
     end


### PR DESCRIPTION
Implement support for options per host:

e.g.:

default options, use `sidekiq_options_per_process`:

```
set :sidekiq_role, [:sidekiq_job]

# default sidekiq settings for Ibiza
set :sidekiq_options_per_process, [
  '--concurrency 10  --queue high,2 --queue default'
]
set :sidekiq_job_processes, 1
```

host specific options, use `{role}_options_per_process`:

```
set :sidekiq_role, [:mckinley_sidekiq]

# mckinley specific sidekiq options
set :mckinley_sidekiq_options_per_process, [
  '--concurrency 3 --queue mckinley'
]
set :mckinley_sidekiq_processes, 1
```
