### PR TITLE
[DevOps] Parallelize sidekiq, monit operation via ssh

### DIFF
--- a/capistrano-sidekiq.gemspec
+++ b/capistrano-sidekiq.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'capistrano'
   spec.add_dependency 'sidekiq'
+  spec.add_dependency 'parallel'
 end

--- a/lib/capistrano/sidekiq.rb
+++ b/lib/capistrano/sidekiq.rb
@@ -3,3 +3,4 @@ if Gem::Specification.find_by_name('capistrano').version >= Gem::Version.new('3.
 else
   require_relative 'tasks/capistrano2'
 end
+require 'parallel'

--- a/lib/capistrano/tasks/monit.cap
+++ b/lib/capistrano/tasks/monit.cap
@@ -45,7 +45,6 @@ namespace :sidekiq do
       Array(fetch(:sidekiq_role)).each do |role_name|
         on roles(role_name) do
           processes_num = sidekiq_processes(role_name)
-          puts "Concurrency Num #{fetch(:monit_operation_concurrency_num)}"
           Parallel.each((0...processes_num), in_threads: fetch(:monit_operation_concurrency_num)) do |idx|
             begin
               sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"

--- a/lib/capistrano/tasks/monit.cap
+++ b/lib/capistrano/tasks/monit.cap
@@ -4,6 +4,7 @@ namespace :load do
     set :sidekiq_monit_use_sudo, -> { true }
     set :monit_bin, -> { '/usr/bin/monit' }
     set :sidekiq_monit_default_hooks, -> { true }
+    set :monit_operation_concurrency_num, -> { fetch(:sidekiq_operation_concurrency_num) }
   end
 end
 
@@ -43,7 +44,9 @@ namespace :sidekiq do
     task :monitor do
       Array(fetch(:sidekiq_role)).each do |role_name|
         on roles(role_name) do
-          sidekiq_processes(role_name).times do |idx|
+          processes_num = sidekiq_processes(role_name)
+          puts "Concurrency Num #{fetch(:monit_operation_concurrency_num)}"
+          Parallel.each((0...processes_num), in_threads: fetch(:monit_operation_concurrency_num)) do |idx|
             begin
               sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"
             rescue
@@ -59,7 +62,8 @@ namespace :sidekiq do
     task :unmonitor do
       Array(fetch(:sidekiq_role)).each do |role_name|
         on roles(role_name) do
-          sidekiq_processes(role_name).times do |idx|
+          processes_num = sidekiq_processes(role_name)
+          Parallel.each((0...processes_num), in_threads: fetch(:monit_operation_concurrency_num)) do |idx|
             begin
               sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sidekiq_service_name(idx)}"
             rescue
@@ -74,7 +78,8 @@ namespace :sidekiq do
     task :start do
       Array(fetch(:sidekiq_role)).each do |role_name|
         on roles(role_name) do
-          sidekiq_processes(role_name).times do |idx|
+          processes_num = sidekiq_processes(role_name)
+          Parallel.each((0...processes_num), in_threads: fetch(:monit_operation_concurrency_num)) do |idx|
             sudo_if_needed "#{fetch(:monit_bin)} start #{sidekiq_service_name(idx)}"
           end
         end
@@ -85,7 +90,8 @@ namespace :sidekiq do
     task :stop do
       Array(fetch(:sidekiq_role)).each do |role_name|
         on roles(role_name) do
-          sidekiq_processes(role_name).times do |idx|
+          processes_num = sidekiq_processes(role_name)
+          Parallel.each((0...processes_num), in_threads: fetch(:monit_operation_concurrency_num)) do |idx|
             sudo_if_needed "#{fetch(:monit_bin)} stop #{sidekiq_service_name(idx)}"
           end
         end
@@ -96,7 +102,8 @@ namespace :sidekiq do
     task :restart do
       Array(fetch(:sidekiq_role)).each do |role_name|
         on roles(role_name) do
-          sidekiq_processes(role_name).times do |idx|
+          processes_num = sidekiq_processes(role_name)
+          Parallel.each((0...processes_num), in_threads: fetch(:monit_operation_concurrency_num)) do |idx|
             sudo_if_needed"#{fetch(:monit_bin)} restart #{sidekiq_service_name(idx)}"
           end
         end

--- a/lib/capistrano/tasks/sidekiq.cap
+++ b/lib/capistrano/tasks/sidekiq.cap
@@ -9,6 +9,10 @@ namespace :load do
     set :sidekiq_role, -> { :app }
     set :sidekiq_processes, -> { 1 }
     set :sidekiq_options_per_process, -> { nil }
+    set :sidekiq_operation_concurrency_num, -> { 0 }
+    # Single thread. If you specify more than 2, operations (eg: sidekiq:start) is executed
+    # in multi threads. @see https://github.com/grosser/parallel#tips
+
     # Rbenv and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a.concat(%w(sidekiq sidekiqctl))
     set :rvm_map_bins, fetch(:rvm_map_bins).to_a.concat(%w(sidekiq sidekiqctl))
@@ -31,7 +35,7 @@ namespace :sidekiq do
     pids = processes_pids
     pids.reverse! if reverse
     within release_path do
-      Parallel.each_with_index(pids, in_threads: processes_pids.count) do |pid_file, idx|
+      Parallel.each_with_index(pids, in_threads: fetch(:sidekiq_operation_concurrency_num)) do |pid_file, idx|
         yield(pid_file, idx)
       end
     end

--- a/lib/capistrano/tasks/sidekiq.cap
+++ b/lib/capistrano/tasks/sidekiq.cap
@@ -30,8 +30,8 @@ namespace :sidekiq do
   def for_each_process(reverse = false, &block)
     pids = processes_pids
     pids.reverse! if reverse
-    pids.each_with_index do |pid_file, idx|
-      within release_path do
+    within release_path do
+      Parallel.each_with_index(pids, in_threads: processes_pids.count) do |pid_file, idx|
         yield(pid_file, idx)
       end
     end


### PR DESCRIPTION
### 変更内容

Capistranoでのデプロイ時に、
sidekiqとmonitの処理について、サーバ毎にパラレルでは動いていましたが、
サーバ内で複数のプロセスに対して処理を行う部分はシリアルに動作していました。
→
サーバ内の複数のプロセスに対しての処理に対してもパラレルで動く様に修正しました。
### 確認方法

[こちら](https://github.com/torchlight-dev/Ibiza/pull/2210)のPRと同様なので、
↑の確認がOKでしたら動作的には問題ありません。
