### PR TITLE
Make run sidekiq:monit:config on deploying

### DIFF
--- a/lib/capistrano/tasks/monit.cap
+++ b/lib/capistrano/tasks/monit.cap
@@ -21,7 +21,8 @@ namespace :sidekiq do
 
     task :add_default_hooks do
       before 'deploy:updating',  'sidekiq:monit:unmonitor'
-      after  'deploy:published', 'sidekiq:monit:monitor'
+      after  'deploy:published', 'sidekiq:monit:config'
+      after  'sidekiq:monit:config', 'sidekiq:monit:monitor'
     end
 
     desc 'Config Sidekiq monit-service'


### PR DESCRIPTION
I'd like to update monit config on deploying so 
I added a hook before monitor starting.
