### PR TITLE
Changed rescue to avoid the error

### DIFF
--- a/lib/capistrano/tasks/monit.cap
+++ b/lib/capistrano/tasks/monit.cap
@@ -36,7 +36,7 @@ namespace :sidekiq do
 
           remaining_memory = fetch(:monit_remaining_memory)
           default_memory = fetch(:monit_default_memory)
-          total_memory = capture(:free, '-m').split("\n")[1].split("\s")[1].to_i rescue total_memory = nil
+          total_memory = capture(:free, '-m').split("\n")[1].split("\s")[1].to_i rescue total_memory = 8192
           processes_num = sidekiq_processes(role_name)
 
           target_memory = (total_memory - remaining_memory) / processes_num if total_memory

--- a/lib/capistrano/tasks/monit.cap
+++ b/lib/capistrano/tasks/monit.cap
@@ -36,6 +36,7 @@ namespace :sidekiq do
 
           remaining_memory = fetch(:monit_remaining_memory)
           default_memory = fetch(:monit_default_memory)
+          # If failed getting public_hostname, capture(:free) will fail so we need `rescue`
           # Most spot instances have 8GB memory so we introduce 8GB as the default value
           total_memory = capture(:free, '-m').split("\n")[1].split("\s")[1].to_i rescue total_memory = 8192
           processes_num = sidekiq_processes(role_name)

--- a/lib/capistrano/tasks/monit.cap
+++ b/lib/capistrano/tasks/monit.cap
@@ -36,6 +36,7 @@ namespace :sidekiq do
 
           remaining_memory = fetch(:monit_remaining_memory)
           default_memory = fetch(:monit_default_memory)
+          # Most spot instances have 8GB memory so we introduce 8GB as the default value
           total_memory = capture(:free, '-m').split("\n")[1].split("\s")[1].to_i rescue total_memory = 8192
           processes_num = sidekiq_processes(role_name)
 


### PR DESCRIPTION
- `rescue nil`だと43行目でerrorになる
- 使うinstanceは皆ほぼ8GB memoryである

ということから、`nil`ではなく`8192`にしました。
cf. [寺田さんのレポート](https://torchlight.slack.com/archives/C8K1ZTWKU/p1573187570179800), ,[誠さんのまとめ](https://torchlight.slack.com/archives/C8K1ZTWKU/p1573194021190200?thread_ts=1573187570.179800&cid=C8K1ZTWKU), [関連PR](https://github.com/torchlight-dev/Ibiza/pull/6463)

すみません、このrepositoryのrelease方法(deploy方法: 本番への反映方法)を知りません。AMIを作り直す?のでしたっけ?